### PR TITLE
fix: uenvboot -> uenvdev

### DIFF
--- a/include/configs/xilinx_zynqmp_gx.h
+++ b/include/configs/xilinx_zynqmp_gx.h
@@ -41,9 +41,9 @@
         "fi\0" \
     "uenvboot=" \
         "run uenvexist;" \
-        "if test $uenvboot -ne 2; then " \
+        "if test $uenvdev -ne 2; then " \
             "run loadbootenv; " \
-            "echo Loaded environment from mmc${uenvboot}/${bootenv}; " \
+            "echo Loaded environment from mmc${uenvdev}/${bootenv}; " \
             "run importbootenv; " \
         "fi; " \
         "if test -n $uenvcmd; then " \

--- a/include/configs/xilinx_zynqmp_gx.h
+++ b/include/configs/xilinx_zynqmp_gx.h
@@ -51,6 +51,7 @@
             "run uenvcmd; " \
         "fi\0" \
     "sdboot=run uenvboot || mmc dev $sdbootdev && mmcinfo && run sdroot$sdbootdev; " \
+        "echo cmdline: $bootargs && " \
         "load mmc $sdbootdev:$partid $fdt_addr system.dtb && " \
         "load mmc $sdbootdev:$partid $kernel_addr Image && " \
         "booti $kernel_addr - $fdt_addr\0" \


### PR DESCRIPTION
どうやらこの修正が無いと「uEnv.txt に "sdbootdev=1" を追加することで SDブート」しなそうです。

- 関連PR: groove-x/reglus_debian#6
- slack: https://groove-x.slack.com/archives/C01V7CJ2PPS/p1630298080022800?thread_ts=1630054866.014900&cid=C01V7CJ2PPS

それか、SDブートに直接関係するのはこのコミットかも（gx ブランチにあるけど、 reglus_debian の submodule に反映されてなかった）
- https://github.com/groove-x/u-boot-xlnx/commit/36a6f18983532a4c55bf994bb59697cff5ac1b0a

CC: @puhitaku @k-asano-adt 